### PR TITLE
update doc with correct default value

### DIFF
--- a/lib/App/git/ship.pm
+++ b/lib/App/git/ship.pm
@@ -475,7 +475,7 @@ The example below will result in "## 0.42 (2014-01-28)".
 "%v" will be replaced by the version, while the format arguments are passed
 on to L<POSIX/strftime>.
 
-The default is "%-7v  %a %b %e %H:%M:%S %Y".
+The default is "%v %Y-%m-%dT%H:%M:%S%z".
 
 =item * project_name
 


### PR DESCRIPTION
Some how the actual default value for new_version_format got out of sync with the documentation.

Actual default value:

https://github.com/jhthorsen/app-git-ship/blob/master/lib/App/git/ship/perl.pm#L307
