### PR TITLE
Fix META_MERGE for Makefile.PL

### DIFF
--- a/lib/App/git/ship/perl.pm
+++ b/lib/App/git/ship/perl.pm
@@ -567,17 +567,15 @@ my %WriteMakefileArgs = (
   TEST_REQUIRES  => <%= $_[1]->{TEST_REQUIRES} %>,
   PREREQ_PM      => <%= $_[1]->{PREREQ_PM} %>,
   META_MERGE     => {
-    resources => {
-      'dynamic_config' => 0,
-      'meta-spec'      => {version => 2},
-      'resources'      => {
-        bugtracker => {web => '<%= $_[0]->config->{bugtracker} %>'},
-        homepage   => '<%= $_[0]->config->{homepage} %>',
-        repository => {
-          type => 'git',
-          url  => '<%= $_[0]->repository %>',
-          web  => '<%= $_[0]->config->{homepage} %>',
-        },
+    'dynamic_config' => 0,
+    'meta-spec'      => {version => 2},
+    'resources'      => {
+      bugtracker => {web => '<%= $_[0]->config->{bugtracker} %>'},
+      homepage   => '<%= $_[0]->config->{homepage} %>',
+      repository => {
+        type => 'git',
+        url  => '<%= $_[0]->repository %>',
+        web  => '<%= $_[0]->config->{homepage} %>',
       },
     },
   },


### PR DESCRIPTION
Currently app-git-ship emits incorrect META.json. This PR will fix this.

before
https://gist.github.com/skaji/6a44c5f73ae2a51ae08cb48d6bcf872d#file-00_before_meta-json

after
https://gist.github.com/skaji/6a44c5f73ae2a51ae08cb48d6bcf872d#file-01_after_meta-json