### PR TITLE
Correct examples for git aliases

### DIFF
--- a/lib/App/git/ship.pm
+++ b/lib/App/git/ship.pm
@@ -262,14 +262,14 @@ See L<App::git::ship::perl/SYNOPSIS> for how to build Perl projects.
 Below is a list of useful git aliases:
 
   # git build
-  $ git config --global alias.build = ship build
+  $ git config --global alias.build 'ship build'
 
   # git cl
-  $ git config --global alias.cl = ship clean
+  $ git config --global alias.cl 'ship clean'
 
   # git start
   # git start My/Project.pm
-  $ git config --global alias.start = ship start
+  $ git config --global alias.start 'ship start'
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
Syntax is
```
git config --global alias.somealias somecommand
git config --global alias.somealias 'some long command'
```
See https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases.