### PR TITLE
switch off color in git branch command 

### DIFF
--- a/lib/App/git/ship.pm
+++ b/lib/App/git/ship.pm
@@ -113,7 +113,7 @@ sub run_hook {
 
 sub ship {
   my $self     = shift;
-  my ($branch) = qx(git branch) =~ /\* (.+)$/m;
+  my ($branch) = qx(git branch --no-color) =~ /\* (.+)$/m;
   my ($remote) = qx(git remote -v) =~ /^origin\s+(.+)\s+\(push\)$/m;
 
   $self->abort("Cannot ship without a current branch") unless $branch;


### PR DESCRIPTION
Some users have the following in their `~/.gitconfig` which hinders the correct parsing of `git branch` when determining the branch.

```config
[color]
        ui = always
```

Adding the `--no-color` flag overrides this.