### PR TITLE
use Applify subcommands

### DIFF
--- a/lib/App/git/ship.pm
+++ b/lib/App/git/ship.pm
@@ -1,7 +1,7 @@
 package App::git::ship;
 use Mojo::Base -base;
 
-use Carp;
+use Carp         ();
 use Data::Dumper ();
 use IPC::Run3    ();
 use Mojo::File 'path';
@@ -169,7 +169,7 @@ sub system {
 sub _build_config {
   my $self = shift;
 
-  my $file   = $ENV{GIT_SHIP_CONFIG} || '.ship.conf';
+  my $file = $ENV{GIT_SHIP_CONFIG} || '.ship.conf';
   my $config = {};
   return $config unless open my $CFG, '<:encoding(UTF-8)', $file;
 
@@ -191,7 +191,7 @@ sub _build_config {
 }
 
 sub _build_config_param_author {
-  my $self   = shift;
+  my $self = shift;
   my $format = shift || '%an <%ae>';
 
   open my $GIT, '-|', qw(git log), "--format=$format"
@@ -242,7 +242,7 @@ sub _get_template {
   my $str;
   no strict 'refs';
   for my $package ($class, @{"$class\::ISA"}) {
-    $str  = Mojo::Loader::data_section($package, $name) or next;
+    $str = Mojo::Loader::data_section($package, $name) or next;
     $name = "$package/$name";
     last;
   }

--- a/script/git-ship
+++ b/script/git-ship
@@ -1,26 +1,42 @@
 #!/usr/bin/env perl
 use Applify;
 use App::git::ship;
+use Mojo::Util 'monkey_patch';
 
 documentation 'App::git::ship';
 version 'App::git::ship';
 
+subcommand build    => 'Build the project'          => _applify('build');
+subcommand clean    => 'Clean unwanted files'       => _applify('clean');
+subcommand coverage => 'Test coverage'              => _applify('test_coverage');
+subcommand start    => 'Start a project'            => sub { };
+subcommand upload   => 'Upload project to git/cpan' => _applify('ship');
+
+sub _applify {
+  my ($method) = shift;
+  return sub {
+    my $applify = shift;
+    my $class   = App::git::ship->new->detect;
+    my $subcmd  = $applify->documentation($class)->extends($class)->subcommand;
+
+    monkey_patch $class, "command_$subcmd" => sub {
+      shift->$method(@_);
+      return 0;
+    };
+  };
+}
+
+sub command_start {
+  my $self = shift;
+  App::git::ship->new->start(@_);
+  return 0;
+}
+
+
 app {
-  my $self   = shift;
-  my $action = shift || 'ship';
-  my $ship   = App::git::ship->new;
-
-  $action =~ s/-/_/g;
-
-  if ($action eq 'start') {
-    $ship->start(@_);
-  }
-  else {
-    $ship = $ship->detect->new;
-    $ship->config;
-    $ship->abort("Unknown action: $action") if $action !~ /^[a-z_]+$/ or !$ship->can($action);
-    $ship->$action(@_);
-  }
-
+  my $self = shift;
+  my $ship = App::git::ship->new->detect->new;
+  $ship->config;
+  $ship->ship(@_);
   return 0;
 };


### PR DESCRIPTION
Improve the user interface. The help is now from the correct class and the available commands are documented.

```
Usage:

    git-ship [command] [options]

commands:
    build     Build the project
    clean     Clean unwanted files
    coverage  Test coverage
    start     Start a project
    upload    Upload project to git/cpan

options:

   --help     Print this help text
   --man      Display manual for this application
   --version  Print application name and version
```
