### PR TITLE
Set Perl version to 5.14.4, Applify to 0.20

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
+requires "perl"                => "5.014004";
 requires "Mojolicious"         => "8.00";
-requires "Applify"             => "0.06";
+requires "Applify"             => "0.20";
 requires "Pod::Markdown"       => "3.00";
 requires "CPAN::Uploader"      => "0.10";
 requires "ExtUtils::MakeMaker" => "6.00";


### PR DESCRIPTION
CPAN testers are not able to install this module on Perl versions below 5.14.4, maybe because of Applify. See https://github.com/jhthorsen/applify/pull/29.