### PR TITLE
Allow env vars to precede makefile e.g. TAR=gnutar

### DIFF
--- a/lib/App/git/ship/perl.pm
+++ b/lib/App/git/ship/perl.pm
@@ -28,7 +28,7 @@ sub build {
   $self->_update_version_info;
   $self->_render_readme;
   $self->_make('manifest');
-  $self->_make('dist');
+  $self->_make('dist', '-e');
   $self->run_hook('after_build');
   $self;
 }


### PR DESCRIPTION
So that `TAR=gnutar git ship build` uses `gnutar` rather than EUMM default.

From `man make`

```
       -e, --environment-overrides
            Give variables taken from the environment precedence over variables from makefiles.
```